### PR TITLE
Make ObservationManager init function public

### DIFF
--- a/Hanson/Observation Manager/ObservationManager.swift
+++ b/Hanson/Observation Manager/ObservationManager.swift
@@ -15,6 +15,10 @@ public class ObservationManager {
     
     internal let lock = NSRecursiveLock("com.blendle.hanson.observation-manager")
     
+    public init() {
+        
+    }
+    
     deinit {
         unobserveAll()
     }


### PR DESCRIPTION
This makes the `init` function of the `ObservationManager` public so that conformance to the `Observer` protocol is possible outside of the framework. 

Related: https://github.com/blendle/Hanson/issues/12