### PR TITLE
Add EventScheduler support

### DIFF
--- a/Hanson.xcodeproj/project.pbxproj
+++ b/Hanson.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		C8DBC7631E3A4E2E0028E936 /* TestObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8DBC7611E3A4E2E0028E936 /* TestObject.swift */; };
 		C8DBC7641E3A4E2E0028E936 /* TestEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8DBC7621E3A4E2E0028E936 /* TestEventPublisher.swift */; };
 		C8EB01DC1E435A0F0036E3C9 /* CustomBindableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EB01DB1E435A0F0036E3C9 /* CustomBindableTests.swift */; };
+		CE68BC6925545B8600257431 /* EventScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE68BC6825545B8600257431 /* EventScheduler.swift */; };
+		CE68BC6D25545DE700257431 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE68BC6C25545DE700257431 /* CurrentThreadScheduler.swift */; };
+		CE68BC7125545E0400257431 /* MainThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE68BC7025545E0400257431 /* MainThreadScheduler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +72,9 @@
 		C8DBC7611E3A4E2E0028E936 /* TestObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestObject.swift; sourceTree = "<group>"; };
 		C8DBC7621E3A4E2E0028E936 /* TestEventPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEventPublisher.swift; sourceTree = "<group>"; };
 		C8EB01DB1E435A0F0036E3C9 /* CustomBindableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomBindableTests.swift; sourceTree = "<group>"; };
+		CE68BC6825545B8600257431 /* EventScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventScheduler.swift; sourceTree = "<group>"; };
+		CE68BC6C25545DE700257431 /* CurrentThreadScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentThreadScheduler.swift; sourceTree = "<group>"; };
+		CE68BC7025545E0400257431 /* MainThreadScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadScheduler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +167,7 @@
 			children = (
 				C8888E801E9CCA7C00803644 /* Observation Manager */,
 				C8888E761E9CCA7C00803644 /* Event Publisher */,
+				CE68BC6725545B4600257431 /* Event Scheduler */,
 				C8888E7D1E9CCA7C00803644 /* Observable */,
 				C8888E731E9CCA7C00803644 /* Bindable */,
 				C8888E7A1E9CCA7C00803644 /* Helpers */,
@@ -192,6 +199,16 @@
 				C8DBC7621E3A4E2E0028E936 /* TestEventPublisher.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		CE68BC6725545B4600257431 /* Event Scheduler */ = {
+			isa = PBXGroup;
+			children = (
+				CE68BC6825545B8600257431 /* EventScheduler.swift */,
+				CE68BC6C25545DE700257431 /* CurrentThreadScheduler.swift */,
+				CE68BC7025545E0400257431 /* MainThreadScheduler.swift */,
+			);
+			path = "Event Scheduler";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -307,7 +324,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE68BC7125545E0400257431 /* MainThreadScheduler.swift in Sources */,
 				C8237A5C1ED82978003279DB /* NotificationObservable.swift in Sources */,
+				CE68BC6925545B8600257431 /* EventScheduler.swift in Sources */,
 				C8888E841E9CCA7C00803644 /* Bindable.swift in Sources */,
 				C8888E8F1E9CCA7C00803644 /* Observer.swift in Sources */,
 				C8888E861E9CCA7C00803644 /* EventHandler.swift in Sources */,
@@ -319,6 +338,7 @@
 				C8888E871E9CCA7C00803644 /* EventPublisher.swift in Sources */,
 				C8888E881E9CCA7C00803644 /* ValueChange.swift in Sources */,
 				C8888E891E9CCA7C00803644 /* NSObject+Observer.swift in Sources */,
+				CE68BC6D25545DE700257431 /* CurrentThreadScheduler.swift in Sources */,
 				C8888E8E1E9CCA7C00803644 /* ObservationManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Hanson.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Hanson.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Hanson/Bindable/CustomBindable.swift
+++ b/Hanson/Bindable/CustomBindable.swift
@@ -52,13 +52,14 @@ public extension ObservationManager {
     ///
     /// - Parameters:
     ///   - eventPublisher: The event publisher to observe for value changes.
+    ///   - eventScheduler: The scheduler to be used by the event publisher and for setting the initial value.
     ///   - target: The target that owns the variable that is being wrapped.
     ///   - setter: The setter that is invoked to change the wrapped variable's value.
     /// - Returns: The observation that has been created.
     @discardableResult
-    func bind<E: EventPublisher & Bindable, Target: AnyObject>(_ eventPublisher: E, to target: Target, setter: @escaping CustomBindable<Target, E.Value>.Setter) -> Observation {
+    func bind<E: EventPublisher & Bindable, Target: AnyObject>(_ eventPublisher: E, with eventScheduler: EventScheduler = CurrentThreadScheduler(), to target: Target, setter: @escaping CustomBindable<Target, E.Value>.Setter) -> Observation {
         let customBindable = CustomBindable(target: target, setter: setter)
-        let observation = bind(eventPublisher, to: customBindable)
+        let observation = bind(eventPublisher, with: eventScheduler, to: customBindable)
         
         return observation
     }
@@ -72,12 +73,13 @@ public extension Observer {
     ///
     /// - Parameters:
     ///   - eventPublisher: The event publisher to observe for value changes.
+    ///   - eventScheduler: The scheduler to be used by the event publisher and for setting the initial value.
     ///   - target: The target that owns the variable that is being wrapped.
     ///   - setter: The setter that is invoked to change the wrapped variable's value.
     /// - Returns: The observation that has been created.
     @discardableResult
-    func bind<E: EventPublisher & Bindable, Target: AnyObject>(_ eventPublisher: E, to target: Target, setter: @escaping CustomBindable<Target, E.Value>.Setter) -> Observation {
-        return observationManager.bind(eventPublisher, to: target, setter: setter)
+    func bind<E: EventPublisher & Bindable, Target: AnyObject>(_ eventPublisher: E, with eventScheduler: EventScheduler = CurrentThreadScheduler(), to target: Target, setter: @escaping CustomBindable<Target, E.Value>.Setter) -> Observation {
+        return observationManager.bind(eventPublisher, with: eventScheduler, to: target, setter: setter)
     }
     
 }

--- a/Hanson/Event Publisher/EventPublisher.swift
+++ b/Hanson/Event Publisher/EventPublisher.swift
@@ -64,12 +64,7 @@ public extension EventPublisher {
     }
 
     @discardableResult
-    func addEventHandler(_ eventHandler: @escaping EventHandler<Event>) -> EventHandlerToken {
-        addEventHandler(eventHandler, eventScheduler: CurrentThreadScheduler())
-    }
-
-    @discardableResult
-    func addEventHandler(_ eventHandler: @escaping EventHandler<Event>, eventScheduler: EventScheduler) -> EventHandlerToken {
+    func addEventHandler(_ eventHandler: @escaping EventHandler<Event>, eventScheduler: EventScheduler = CurrentThreadScheduler()) -> EventHandlerToken {
         lock.lock()
         defer { lock.unlock() }
         

--- a/Hanson/Event Publisher/EventPublisher.swift
+++ b/Hanson/Event Publisher/EventPublisher.swift
@@ -13,16 +13,18 @@ public protocol EventPublisher: class {
     
     /// The type of event that the event publisher publishes.
     associatedtype Event
-    
-    /// The event handlers that should be invoked when an event is published.
-    var eventHandlers: [EventHandlerToken: EventHandler<Event>] { get set }
-    
+
+    /// The event handlers and their schedulers that should be invoked when an event is published.
+    var eventHandlers: [EventHandlerToken: (eventHandler: EventHandler<Event>, eventScheduler: EventScheduler)] { get set }
+
     /// Adds an event handler.
     ///
-    /// - Parameter eventHandler: The event handler to invoke when an event is published.
+    /// - Parameters:
+    ///   - eventHandler: The event handler to invoke when an event is published.
+    ///   - eventScheduler: The scheduler to be used by the event publisher.
     /// - Returns: A token, usable to identify and remove the event handler later on.
     @discardableResult
-    func addEventHandler(_ eventHandler: @escaping EventHandler<Event>) -> EventHandlerToken
+    func addEventHandler(_ eventHandler: @escaping EventHandler<Event>, eventScheduler: EventScheduler) -> EventHandlerToken
     
     /// Invoked when an event handler has been added.
     /// This provides an opportunity to set up resources used for publishing events.
@@ -48,24 +50,32 @@ public protocol EventPublisher: class {
 }
 
 public extension EventPublisher {
-    
+
     func publish(_ event: Event) {
         lock.lock()
         defer { lock.unlock() }
-        
-        eventHandlers.forEach { _, eventHandler in
-            eventHandler(event)
+
+        eventHandlers.forEach { _, value in
+            let (eventHandler, eventScheduler) = value
+            eventScheduler.scheduleEvent {
+                eventHandler(event)
+            }
         }
     }
-    
+
     @discardableResult
     func addEventHandler(_ eventHandler: @escaping EventHandler<Event>) -> EventHandlerToken {
+        addEventHandler(eventHandler, eventScheduler: CurrentThreadScheduler())
+    }
+
+    @discardableResult
+    func addEventHandler(_ eventHandler: @escaping EventHandler<Event>, eventScheduler: EventScheduler) -> EventHandlerToken {
         lock.lock()
         defer { lock.unlock() }
         
         let eventHandlerToken = EventHandlerToken()
-        eventHandlers[eventHandlerToken] = eventHandler
-        
+        eventHandlers[eventHandlerToken] = (eventHandler, eventScheduler)
+
         didAddEventHandler()
         
         return eventHandlerToken

--- a/Hanson/Event Scheduler/CurrentThreadScheduler.swift
+++ b/Hanson/Event Scheduler/CurrentThreadScheduler.swift
@@ -1,0 +1,23 @@
+//
+//  CurrentThreadScheduler.swift
+//  Hanson
+//
+//  Created by Bram Schulting on 05/11/2020.
+//  Copyright © 2020 Blendle. All rights reserved.
+//
+
+import Foundation
+
+/// An `EventScheduler` that schedules events immediately in the current thread. Events will be published from the
+/// thread the scheduler is called from (which is the thread the observable value is changed from).
+public class CurrentThreadScheduler: EventScheduler {
+
+    public init() {
+        
+    }
+
+    public func scheduleEvent(closure: @escaping () -> Void) {
+        closure()
+    }
+
+}

--- a/Hanson/Event Scheduler/EventScheduler.swift
+++ b/Hanson/Event Scheduler/EventScheduler.swift
@@ -1,0 +1,22 @@
+//
+//  EventScheduler.swift
+//  Hanson
+//
+//  Created by Bram Schulting on 05/11/2020.
+//  Copyright © 2020 Blendle. All rights reserved.
+//
+
+import Foundation
+
+/// Types conforming to `EventScheduler` can be used to schedule events for specific moments. By default Hanson uses an
+/// instance of `CurrentThreadScheduler` which publishes events immediately, on the thread the process is already on at
+/// that moment (which is the thread were the observable value is changed). Hanson also provides the
+/// `MainThreadScheduler` which ensures the event is published on the main thread, regardless of from which thread the
+/// value is changed.
+public protocol EventScheduler {
+
+    /// Method that will be called by the `EventPublisher` when it wants to publish an event.
+    /// - Parameter closure: The closure in which the event will be sent.
+    func scheduleEvent(closure: @escaping () -> Void)
+
+}

--- a/Hanson/Event Scheduler/MainThreadScheduler.swift
+++ b/Hanson/Event Scheduler/MainThreadScheduler.swift
@@ -1,0 +1,31 @@
+//
+//  MainThreadScheduler.swift
+//  Hanson
+//
+//  Created by Bram Schulting on 05/11/2020.
+//  Copyright © 2020 Blendle. All rights reserved.
+//
+
+import Foundation
+
+/// An `EventScheduler` that makes sure events are scheduled from the main thread, regardless from which thread it is
+/// called. This scheduler is useful when performing UI changes while observing a value that can be changed from a
+/// background thread.
+public class MainThreadScheduler: EventScheduler {
+
+    public init() {
+
+    }
+
+    public func scheduleEvent(closure: @escaping () -> Void) {
+        // If we're already on the main thread, we can call the closure immediately
+        if Thread.isMainThread {
+            return closure()
+        }
+
+        DispatchQueue.main.async {
+            closure()
+        }
+    }
+
+}

--- a/Hanson/Observable/DynamicObservable.swift
+++ b/Hanson/Observable/DynamicObservable.swift
@@ -98,8 +98,8 @@ public class DynamicObservable<Value>: NSObject, EventPublisher, Bindable {
     
     // MARK: Event Handlers
     
-    /// The event handlers to be invoked when the dynamic observable updates its value.
-    public var eventHandlers: [EventHandlerToken: EventHandler<ValueChange<Value>>] = [:]
+    /// The event handlers and their schedulers to be invoked when the dynamic observable updates its value.
+    public var eventHandlers: [EventHandlerToken: (eventHandler: EventHandler<ValueChange<Value>>, eventScheduler: EventScheduler)] = [:]
     
     /// Invoked when an event handler is added.
     public func didAddEventHandler() {

--- a/Hanson/Observable/NotificationObservable.swift
+++ b/Hanson/Observable/NotificationObservable.swift
@@ -69,8 +69,8 @@ public class NotificationObservable: EventPublisher {
     
     // MARK: Event Handlers
     
-    /// The event handlers to be invoked when the dynamic observable updates its value.
-    public var eventHandlers: [EventHandlerToken: EventHandler<Notification>] = [:]
+    /// The event handlers and their schedulers to be invoked when the dynamic observable updates its value.
+    public var eventHandlers: [EventHandlerToken: (eventHandler: EventHandler<Notification>, eventScheduler: EventScheduler)] = [:]
     
     /// Invoked when an event handler is added.
     public func didAddEventHandler() {

--- a/Hanson/Observable/Observable.swift
+++ b/Hanson/Observable/Observable.swift
@@ -60,9 +60,9 @@ public class Observable<Value>: EventPublisher, Bindable {
     
     // MARK: Event Handlers
     
-    /// The event handlers to be invoked when the observable updates its value.
-    public var eventHandlers: [EventHandlerToken: EventHandler<ValueChange<Value>>] = [:]
-    
+    /// The event handlers and their schedulers to be invoked when the observable updates its value.
+    public var eventHandlers: [EventHandlerToken: (eventHandler: EventHandler<ValueChange<Value>>, eventScheduler: EventScheduler)] = [:]
+
     // MARK: Lock
     
     /// The lock used for operations related to event handlers and event publishing.

--- a/Hanson/Observation Manager/Observer.swift
+++ b/Hanson/Observation Manager/Observer.swift
@@ -22,22 +22,24 @@ public extension Observer {
     ///
     /// - Parameters:
     ///   - eventPublisher: The event publisher to observe.
+    ///   - eventScheduler: The scheduler to be used by the event publisher.
     ///   - eventHandler: The handler to invoke when an event is published.
     /// - Returns: The observation that has been created.
     @discardableResult
-    func observe<E: EventPublisher>(_ eventPublisher: E, eventHandler: @escaping EventHandler<E.Event>) -> Observation {
-        return observationManager.observe(eventPublisher, eventHandler: eventHandler)
+    func observe<E: EventPublisher>(_ eventPublisher: E, with eventScheduler: EventScheduler = CurrentThreadScheduler(), eventHandler: @escaping EventHandler<E.Event>) -> Observation {
+        return observationManager.observe(eventPublisher, with: eventScheduler, eventHandler: eventHandler)
     }
     
     /// Binds the value of a bindable event publisher to a bindable.
     ///
     /// - Parameters:
     ///   - eventPublisher: The event publisher to observe for value changes.
+    ///   - eventScheduler: The scheduler to be used by the event publisher and for setting the initial value.
     ///   - bindable: The bindable to update with the value changes of the event publisher.
     /// - Returns: The observation that has been created.
     @discardableResult
-    func bind<E: EventPublisher & Bindable, B: Bindable>(_ eventPublisher: E, to bindable: B) -> Observation where E.Value == B.Value {
-        return observationManager.bind(eventPublisher, to: bindable)
+    func bind<E: EventPublisher & Bindable, B: Bindable>(_ eventPublisher: E, with eventScheduler: EventScheduler = CurrentThreadScheduler(), to bindable: B) -> Observation where E.Value == B.Value {
+        return observationManager.bind(eventPublisher, with: eventScheduler, to: bindable)
     }
     
     /// Removes an observation.

--- a/HansonTests/EventPublisherTests.swift
+++ b/HansonTests/EventPublisherTests.swift
@@ -158,6 +158,44 @@ class EventPublisherTests: XCTestCase {
         // Verify that all event handlers have been removed.
         XCTAssertTrue(eventPublisher.eventHandlers.isEmpty)
     }
+
+    func testPublishingEventWithCurrentThreadScheduler() {
+        let eventPublisher = TestEventPublisher()
+
+        // Add event handler with main thread scheduler
+        let schedulerExpectation = expectation(description: "Event is sent on current thread")
+        eventPublisher.addEventHandler({ _ in
+            XCTAssertFalse(Thread.isMainThread)
+
+            schedulerExpectation.fulfill()
+        }, eventScheduler: CurrentThreadScheduler())
+
+        // Publish event from background thread
+        DispatchQueue.global(qos: .background).async {
+            eventPublisher.publish("Sample event")
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testPublishingEventWithMainThreadScheduler() {
+        let eventPublisher = TestEventPublisher()
+
+        // Add event handler with main thread scheduler
+        let schedulerExpectation = expectation(description: "Event is sent on main thread")
+        eventPublisher.addEventHandler({ _ in
+            XCTAssertTrue(Thread.isMainThread)
+
+            schedulerExpectation.fulfill()
+        }, eventScheduler: MainThreadScheduler())
+
+        // Publish event from background thread
+        DispatchQueue.global(qos: .background).async {
+            eventPublisher.publish("Sample event")
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
     
 }
 

--- a/HansonTests/Helpers/TestEventPublisher.swift
+++ b/HansonTests/Helpers/TestEventPublisher.swift
@@ -13,7 +13,7 @@ class TestEventPublisher: EventPublisher {
     
     typealias Event = String
     
-    var eventHandlers: [EventHandlerToken: EventHandler<String>] = [:]
+    var eventHandlers: [EventHandlerToken: (eventHandler: EventHandler<String>, eventScheduler: EventScheduler)] = [:]
     
     let lock = NSRecursiveLock("com.blendle.hanson.tests.event-publisher")
     

--- a/README.md
+++ b/README.md
@@ -91,6 +91,37 @@ observe(observable) { notification in
 }
 ```
 
+### Schedulers
+
+Schedulers can be used to schedule the events of your observation. By default, Hanson uses the `CurrentThreadScheduler`, which immediatly sends events on whatever thread it currently is. Hanson also offers the `MainThreadScheduler`, which ensures events are sent on the main thread. This is useful when observing a value that can change from a background thread and you want to do UI changes based on that value. For example:
+
+```swift
+let observable = Observable("Hello World")
+observe(observable, with: MainThreadScheduler()) { event in
+    // It's safe to do UI work here without calling DispatchQueue.main.async here
+}
+
+performOnBackground {
+    observable.value = "Hello from a background"
+}
+```
+
+Schedulers are also supported when binding observables:
+
+```swift
+let isLoadingData = Observable(true)
+let activityIndicatorView = UIActivityIndicatorView()
+bind(isLoadingData, with: MainThreadScheduler(), to: activityIndicatorView) { activityIndicatorView, isLoadingData in
+    // It's safe to do UI work here without calling DispatchQueue.main.async here
+}
+
+performOnBackground {
+    isLoadingData.value = false
+}
+```
+
+You can create your own scheduler by conforming to the `EventScheduler` protocol.
+
 ## Requirements
 
 * iOS 8.0+ / macOS 10.9+ / tvOS 9.0+


### PR DESCRIPTION
This PR adds support for event schedulers.

Schedulers can be used to schedule the events of your observation. By default, Hanson uses the `CurrentThreadScheduler`, which immediatly sends events on whatever thread it currently is. Hanson also offers the `MainThreadScheduler`, which ensures events are sent on the main thread. This is useful when observing a value that can change from a background thread and you want to do UI changes based on that value.

This introduces a breaking change to the `EventPublisher` protocol. The `eventHandlers` type has been changed to add support for event schedulers.