### PR TITLE
Update version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 2.0.0 (2020-11-06)
+
+Breaking change:
+
+- Added support for `EventScheduler`. This changes the `EventPublisher` protocol. Apps that use their own implementation of this protocol need to update their implementation.
+
 ### 1.2 (2017-09-26)
 
 - Update for Swift 4.

--- a/Hanson.podspec
+++ b/Hanson.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                      = "Hanson"
-    spec.version                   = "1.3"
+    spec.version                   = "2.0.0"
     spec.summary                   = "Lightweight observations and bindings in Swift"
     spec.homepage                  = "https://github.com/blendle/Hanson"
     spec.license                   = { :type => "ISC", :file => "LICENSE" }

--- a/Hanson/Info.plist
+++ b/Hanson/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Update version to 2.0.0 because of the breaking changes to the `EventPublisher` protocol.