### PR TITLE
Replacing Unowned with Weak

### DIFF
--- a/Hanson/Bindable/CustomBindable.swift
+++ b/Hanson/Bindable/CustomBindable.swift
@@ -16,7 +16,7 @@ public class CustomBindable<Target: AnyObject, Value>: Bindable {
     public typealias Setter = (Target, Value) -> Void
     
     /// The target that owns the variable that is being wrapped.
-    public unowned let target: Target
+    public weak var target: Target?
     
     /// The setter that will be invoked once a new value is received.
     public let setter: Setter
@@ -39,7 +39,9 @@ public class CustomBindable<Target: AnyObject, Value>: Bindable {
         }
         
         set {
-            setter(target, newValue)
+            if let target = target {
+                setter(target, newValue)
+            }
         }
     }
     

--- a/Hanson/Observation Manager/ObservationManager.swift
+++ b/Hanson/Observation Manager/ObservationManager.swift
@@ -58,8 +58,10 @@ public class ObservationManager {
             bindable.value = eventPublisher.value
         }
         
-        let observation = observe(eventPublisher, with: eventScheduler) { [unowned eventPublisher] event in
-            bindable.value = eventPublisher.value
+        let observation = observe(eventPublisher, with: eventScheduler) { [weak eventPublisher] event in
+            if let eventPublisher = eventPublisher {
+                bindable.value = eventPublisher.value
+            }
         }
 
         return observation


### PR DESCRIPTION
The `CustomBindable` object used unowned reference to target which may lead to crashes when used with multiple threads. So its reference type changed to weak. The same thing happening in `ObservationManager`'s bind function. It captures reference of observable as unowned, which may lead to crash. 