### PR TITLE
Fixed: swift compiler warnings against deprecated 'class'

### DIFF
--- a/Hanson/Bindable/Bindable.swift
+++ b/Hanson/Bindable/Bindable.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Types conforming to the `Bindable` protocol can be updated with a new value when an event is published from an `EventPublisher`. Both ends of a binding should implement the `Bindable` protocol, as the receiving bindable will be set to the value of the source bindable when the binding is made.
-public protocol Bindable: class {
+public protocol Bindable: AnyObject {
     
     /// The type of value of the bindable.
     associatedtype Value

--- a/Hanson/Event Publisher/EventPublisher.swift
+++ b/Hanson/Event Publisher/EventPublisher.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Types conforming to the `EventPublisher` protocol can publish and be observed for events.
-public protocol EventPublisher: class {
+public protocol EventPublisher: AnyObject {
     
     /// The type of event that the event publisher publishes.
     associatedtype Event


### PR DESCRIPTION
Nothing about performance but keep an up-to-date codebase.